### PR TITLE
Teacher problem post

### DIFF
--- a/web/attempts/rest.py
+++ b/web/attempts/rest.py
@@ -11,17 +11,17 @@ from .models import Attempt
 class WritableJSONField(Field):
     def to_internal_value(self, data):
         return data
-        
+
 
 class JSONStringField(Field):
     """
     Store a JSON object in a TextField.
     When object is received store its json dump.
-    When object is retrieved load JSON object from string representation. 
+    When object is retrieved load JSON object from string representation.
     """
     def to_internal_value(self, data):
         return json.dumps(data)
-    
+
     def to_representation(self, value):
         return json.loads(value)
 

--- a/web/attempts/rest.py
+++ b/web/attempts/rest.py
@@ -1,29 +1,16 @@
-import json
 from django.db import transaction
 from rest_framework import validators, decorators, status
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.response import Response
 from rest_framework.serializers import ModelSerializer, Field
 from rest_framework.viewsets import ModelViewSet
+from utils.rest import JSONStringField
 from .models import Attempt
 
 
 class WritableJSONField(Field):
     def to_internal_value(self, data):
         return data
-
-
-class JSONStringField(Field):
-    """
-    Store a JSON object in a TextField.
-    When object is received store its json dump.
-    When object is retrieved load JSON object from string representation.
-    """
-    def to_internal_value(self, data):
-        return json.dumps(data)
-
-    def to_representation(self, value):
-        return json.loads(value)
 
 
 class AttemptSerializer(ModelSerializer):

--- a/web/problems/models.py
+++ b/web/problems/models.py
@@ -16,7 +16,7 @@ class Problem(models.Model):
         return user.attempts.filter(part__problem=self)
 
     def user_solutions(self, user):
-        return {attempt.part.id: attempt.solution for attempt in self.user_attempts(user)} 
+        return {attempt.part.id: attempt.solution for attempt in self.user_attempts(user)}
 
     def attempt_file(self, user=None):
         authentication_token = Token.objects.get(user=user) if user else None

--- a/web/problems/rest.py
+++ b/web/problems/rest.py
@@ -1,12 +1,40 @@
+import json
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.serializers import ModelSerializer
-from .models import Problem
+from rest_framework.fields import Field
+from .models import Problem, Part
+
+
+class JSONStringField(Field):
+    """
+    Store a JSON object in a TextField.
+    When object is received store its json dump.
+    When object is retrieved load JSON object from string representation.
+    """
+    def to_internal_value(self, data):
+        return json.dumps(data)
+
+    def to_representation(self, value):
+        return json.loads(value)
+
+
+class PartSerializer(ModelSerializer):
+    """
+    Serialize a Part object instance.
+    """
+    secret = JSONStringField()
+
+    class Meta:
+        model = Part
+        exclude = ('_order',)
 
 
 class ProblemSerializer(ModelSerializer):
     """
     Serialize a Problem object.
     """
+    parts = PartSerializer(many=True)
+
     class Meta:
         model = Problem
 

--- a/web/problems/rest.py
+++ b/web/problems/rest.py
@@ -1,26 +1,15 @@
-import hashlib
 from rest_framework.viewsets import ModelViewSet
-from rest_framework.serializers import ModelSerializer, SerializerMethodField
-from django.conf import settings
+from rest_framework.serializers import ModelSerializer
 from .models import Problem
-
-
-def generate_token(user_id, problem_id, secret_key=settings.SECRET_KEY):
-    return hashlib.sha512('{0}-{1}-{2}'.format(secret_key, user_id, problem_id)).hexdigest()
 
 
 class ProblemSerializer(ModelSerializer):
     """
     Serialize a Problem object.
     """
-    secret = SerializerMethodField()
-
     class Meta:
         model = Problem
 
-    def get_secret(self, problem):
-        return generate_token(self.context['request'].user.id, problem.id)
-        
 
 class ProblemViewSet(ModelViewSet):
     """

--- a/web/problems/rest.py
+++ b/web/problems/rest.py
@@ -1,21 +1,7 @@
-import json
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.serializers import ModelSerializer
-from rest_framework.fields import Field
+from utils.rest import JSONStringField
 from .models import Problem, Part
-
-
-class JSONStringField(Field):
-    """
-    Store a JSON object in a TextField.
-    When object is received store its json dump.
-    When object is retrieved load JSON object from string representation.
-    """
-    def to_internal_value(self, data):
-        return json.dumps(data)
-
-    def to_representation(self, value):
-        return json.loads(value)
 
 
 class PartSerializer(ModelSerializer):

--- a/web/utils/rest.py
+++ b/web/utils/rest.py
@@ -1,0 +1,15 @@
+import json
+from rest_framework.fields import Field
+
+
+class JSONStringField(Field):
+    """
+    Store a JSON object in a TextField.
+    When object is received store its json dump.
+    When object is retrieved load JSON object from string representation.
+    """
+    def to_internal_value(self, data):
+        return json.dumps(data)
+
+    def to_representation(self, value):
+        return json.loads(value)


### PR DESCRIPTION
Dodal sem serializacijo za problem. Zaenkrat je read-only, saj se moramo še domeniti kako bodo učitelji pošiljali kodo na strežnik. 

Pri RESTu se namreč načeloma naredi POST za ustvarjanje in PUT za popravke. Ampak verjetno bomo kdaj tudi v PUT zahtevku ustvarili dodaten del naloge? 

Predlagam, da se naloga ustvari z POST in posodobi s PUT, deli naloge pa se posodobijo, če v bazi že obstaja ustrezni del s pravim ID-jem in je vezan na to nalogo in ustvarijo, če ID-ja bodisi ni bodisi je napačen. Ali to zadnje raje ne?