### PR TITLE
Podpora za octave in druge programske jezike

### DIFF
--- a/web/problems/migrations/0011_auto_20160203_2250.py
+++ b/web/problems/migrations/0011_auto_20160203_2250.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('problems', '0010_auto_20160118_1046'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='historicalproblem',
+            name='language',
+            field=models.CharField(default=b'python', max_length=8, choices=[(b'python', b'Python 3'), (b'octave', b'Octave')]),
+        ),
+        migrations.AddField(
+            model_name='problem',
+            name='language',
+            field=models.CharField(default=b'python', max_length=8, choices=[(b'python', b'Python 3'), (b'octave', b'Octave')]),
+        ),
+    ]

--- a/web/problems/models.py
+++ b/web/problems/models.py
@@ -50,7 +50,6 @@ class Problem(OrderWithRespectToMixin, models.Model):
         filename = "{0}.{1}".format(problem_slug, extension)
         contents = render_to_string("{0}/attempt.{1}".format(self.language, extension), {
             "problem": self,
-            "problem_title": problem_slug,
             "parts": parts,
             "submission_url": url,
             "authentication_token": authentication_token
@@ -84,8 +83,9 @@ class Problem(OrderWithRespectToMixin, models.Model):
     def edit_file(self, user):
         authentication_token = Token.objects.get(user=user)
         url = settings.SUBMISSION_URL + reverse('problems-submit')
-        filename = "{0}-edit.py".format(slugify(self.title))
-        contents = render_to_string("python/edit.py", {
+        problem_slug = slugify(self.title).replace("-","_")
+        filename = "{0}_edit.{1}".format(problem_slug, self.EXTENSIONS[self.language])
+        contents = render_to_string("{0}/edit.{1}".format(self.language, self.EXTENSIONS[self.language]), {
             "problem": self,
             "submission_url": url,
             "authentication_token": authentication_token

--- a/web/problems/models.py
+++ b/web/problems/models.py
@@ -18,7 +18,10 @@ class Problem(OrderWithRespectToMixin, models.Model):
     problem_set = models.ForeignKey('courses.ProblemSet', related_name='problems')
     history = HistoricalRecords()
     tags = TaggableManager(blank=True)
-
+    language = models.CharField(max_length=8, choices=(
+        ('python','Python 3'),
+        ('octave','Octave')), default = 'python')
+    EXTENSIONS = {'python':'py', 'octave': 'm'}
     class Meta:
         order_with_respect_to = 'problem_set'
 
@@ -42,9 +45,12 @@ class Problem(OrderWithRespectToMixin, models.Model):
         solutions = self.user_solutions(user)
         parts = [(part, solutions.get(part.id, '')) for part in self.parts.all()]
         url = settings.SUBMISSION_URL + reverse('attempts-submit')
-        filename = "{0}.py".format(slugify(self.title))
-        contents = render_to_string("python/attempt.py", {
+        problem_slug = slugify(self.title).replace("-","_")
+        extension = self.EXTENSIONS[self.language]
+        filename = "{0}.{1}".format(problem_slug, extension)
+        contents = render_to_string("{0}/attempt.{1}".format(self.language, extension), {
             "problem": self,
+            "problem_title": problem_slug,
             "parts": parts,
             "submission_url": url,
             "authentication_token": authentication_token

--- a/web/problems/templates/octave/attempt.m
+++ b/web/problems/templates/octave/attempt.m
@@ -1,0 +1,289 @@
+global check;
+check = struct();
+# NE BRIŠI prvih dveh vrstic
+
+#
+# =============================================================================
+# {{ problem.title|safe }}{% if problem.description %}
+#
+# {{ problem.description|indent:"# "|safe }}{% endif %}{% for part, solution_attempt in parts %}
+# =====================================================================@{{ part.id|stringformat:'06d'}}=
+# {{ forloop.counter }}. podnaloga
+# {{ part.description|indent:"# "|safe }}
+# =============================================================================
+{{ solution_attempt|safe }}{% endfor %}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# ============================================================================@
+
+
+'Če vam Octave sporoča, da je v tej vrstici sintaktična napaka,';
+'se napaka v resnici skriva v zadnjih vrsticah vaše kode.';
+
+'Kode od tu naprej NE SPREMINJAJTE!';
+
+# check.m
+{% include 'octave/check_functions.m' %}
+# check.m
+# varargin2struct.m
+{% include 'octave/jsonlab.m' %}
+
+function parts = extract_parts(filename)
+    f = fopen(filename, 'r');
+    source = '';
+    while (s = fgets(f)) > -1
+      source = [source s];
+    end
+    fclose(f)
+    part_regex = '# =+@(?<part>\d+)=\n';  # beginning of header
+    part_regex = [part_regex '(#( [^\n]*)?\n)+']; # description
+    part_regex = [part_regex '# =+\n'];           # end of header
+    part_regex = [part_regex '(?<solution>.*?)'];# solution
+    part_regex = [part_regex '(?=\n# =+@)'];     # beginning of next part
+
+    [s, e, te, m, t, nm, sp] = regexp(source,part_regex,'dotall');
+    if iscell(nm.part)
+      parts = [];
+      for i=1:length(nm.part)
+        parts = [parts struct("part",nm.part(i),"solution", strtrim(nm.solution(i)))];
+      end
+    else
+      parts = [struct("part",nm.part,"solution",strtrim(nm.solution))];
+    end
+    # The last solution extends all the way to the validation code,
+    # so we strip any trailing whitespace from it.
+endfunction
+
+function [response,output] = submit_parts(parts, url, token)
+       submited_parts = cell();
+       for part = parts
+           if check_has_solution(part)
+               #data = [data '{ "secret":'
+               part.feedback = savejson('',part.feedback);
+               submited_parts(end+1) = part;
+               #submited_parts(end).feedback = savejson(submited_parts(end).feedback);
+            end
+        end
+       #data = [data "]" ];
+       data = savejson('',submited_parts); #.encode('utf-8')
+       pycall = [...
+       'python3 - 2>&1 << EOF',"\n",...
+       'import json, urllib.request',"\n",...
+       'data = r"""' data '"""',"\n",...
+       'blk_data = data.encode("utf-8")',"\n",...
+       'headers = { "Authorization": "' token '","content-type": "application/json" }',"\n",...
+       'request = urllib.request.Request("' url '", data=blk_data, headers=headers)',"\n",...
+       'response = urllib.request.urlopen(request)',"\n",...
+       'response = json.loads(response.read().decode("utf-8"))',"\n",...
+       'for part in response["attempts"]:',"\n",...
+       '  print("%s: %d" %(part["part"],part["valid"]))',"\n",...
+       'EOF'];
+       # TODO print feedback as well
+       # disp(pycall)
+
+       #'response = post(''' url ''')'
+       #'print(response.text)"']
+       [response,output] = system(pycall);
+       if response
+         disp('PRI SHRANJEVANJU JE PRIŠLO DO NAPAKE! Poskusite znova.')
+         disp(output)
+       else
+         disp('rešitve so shranjene.')
+       end
+       #request = urllib.request.Request(url, data=data, headers=headers)
+       #response = urllib.request.urlopen(request)
+       #return json.loads(response.read().decode('utf-8'))
+endfunction
+function update_attempts(response)
+  global check
+  valid_regex = "([0-9]+): *([01])";
+  [s,e,te,m,t,nm,sp] = regexp(char(response),valid_regex);
+  for i = 1:length(t)
+    for j = 1:length(check.parts)
+      if str2num(check.parts(j).part) == str2num(t{i}{1})
+        # get validation from server response
+        # TODO add feedback
+        check.parts(j).valid = str2num(t{i}{2});
+      end
+    end
+  end
+endfunction
+
+function validation = validate_current_file()
+  global check;
+
+#    def backup(filename):
+#        backup_filename = None
+#        suffix = 1
+#        while not backup_filename or os.path.exists(backup_filename):
+%            backup_filename = '{0}.{1}'.format(filename, suffix)
+%            suffix += 1
+%        shutil.copy(filename, backup_filename)
+%        return backup_filename
+%
+%
+%  filename = argv()(end) # current filename
+  filename = which("{{ problem_title }}");
+  file_parts = extract_parts(filename);
+  check_initialize(file_parts);
+
+  {% for part, _ in parts %}
+      if check_part()
+          try
+              {{ part.validation|default:"0;"|indent:"  "|safe }}
+          catch err
+              check_error(["Testi sprožijo izjemo\n" err.message]);
+          end
+      end
+  {% endfor %}
+
+printf('Shranjujem rešitve na strežnik... ');
+url = "{{ submission_url }}"; #'https://www.projekt-tomo.si/api/attempts/submit/';
+token = "Token {{ authentication_token }}"; #'Token 0779d82c83d98c1e4a5480e4e6f57b906598f5ee';
+response = submit_parts(check.parts, url, token);
+update_attempts(response);
+check_summarize()
+endfunction
+
+validate_current_file();
+# attempt.m

--- a/web/problems/templates/octave/attempt.m
+++ b/web/problems/templates/octave/attempt.m
@@ -187,7 +187,7 @@ function update_attempts(response)
 endfunction
 
 
-function validation = validate_current_file()
+function validation = validate_current_file(src)
   global check;
 
 #    def backup(filename):
@@ -200,8 +200,6 @@ function validation = validate_current_file()
 %        return backup_filename
 %
 %
-  src = char(fileread(mfilename("fullpathext")));
-  fclose(fp);
   file_parts = extract_parts(src);
   check_initialize(file_parts);
 
@@ -219,11 +217,10 @@ function validation = validate_current_file()
 
 submited_parts = cell();
 for part = check.parts
+    part = part{1};
     if check_has_solution(part)
-        #data = [data '{ "secret":'
         part.feedback = savejson('',part.feedback);
-        submited_parts(end+1) = part;
-        #submited_parts(end).feedback = savejson(submited_parts(end).feedback);
+        submited_parts{end+1} = part;
      end
 end
 
@@ -235,5 +232,6 @@ update_attempts(response);
 check_summarize()
 endfunction
 
-validate_current_file();
+src = char(fileread(mfilename("fullpathext")));
+validate_current_file(src);
 # attempt.m

--- a/web/problems/templates/octave/check_functions.m
+++ b/web/problems/templates/octave/check_functions.m
@@ -1,0 +1,64 @@
+function b = check_has_solution(part)
+  b = length(strtrim(part.solution))>0;
+endfunction
+
+function check_initialize(parts)
+  global check;
+  check.parts = parts;
+  for i =1:length(parts)
+    check.parts(i).valid = 1;
+    check.parts(i).feedback = cell();
+    check.parts(i).secret = cell();
+  end
+  check.part_counter = 0;
+endfunction
+
+function r = check_part()
+  global check;
+  check.part_counter = check.part_counter + 1;
+  r = check_has_solution(check.parts(check.part_counter));
+endfunction
+
+function check_error(message)
+  global check;
+  check.parts(check.part_counter).valid = 0;
+  check_feedback(message);
+endfunction
+
+function check_feedback(message)
+  global check;
+	% append feedbact
+  check.parts(check.part_counter).feedback(end+1) = {message};
+endfunction
+
+function res = check_equal(koda, rezultat)
+  global check;
+  res = 0;
+  actual_result = eval(koda);
+  if abs(actual_result - rezultat) > 1e-15
+    check_error(["Izraz ", koda, " vrne ", mat2str(actual_result), " namesto ", mat2str(rezultat)]);
+    res = 1;
+  end
+endfunction
+
+function check_secret(x,hint="")
+  global check;
+  check.parts(check.part_counter).secret{end+1} = x;
+endfunction
+
+function check_summarize()
+  global check;
+  for i=1:check.part_counter
+    if not(check_has_solution(check.parts(i)))
+      printf('%d. podnaloga je brez rešitve.\n', i);
+    elseif not(check.parts(i).valid)
+      printf('%d. podnaloga nima veljavne rešitve.\n',i);
+    else
+      printf('%d. podnaloga ima veljavno rešitev.\n', i);
+    end
+    for j = 1:length(check.parts(i).feedback)
+      printf('  - %d ',j);
+      disp(char(check.parts(i).feedback(j)));
+    end
+  end
+endfunction

--- a/web/problems/templates/octave/check_functions.m
+++ b/web/problems/templates/octave/check_functions.m
@@ -6,9 +6,9 @@ function check_initialize(parts)
   global check;
   check.parts = parts;
   for i =1:length(parts)
-    check.parts(i).valid = 1;
-    check.parts(i).feedback = cell();
-    check.parts(i).secret = cell();
+    check.parts{i}.valid = 1;
+    check.parts{i}.feedback = cell();
+    check.parts{i}.secret = cell();
   end
   check.part_counter = 0;
 endfunction
@@ -16,19 +16,19 @@ endfunction
 function r = check_part()
   global check;
   check.part_counter = check.part_counter + 1;
-  r = check_has_solution(check.parts(check.part_counter));
+  r = check_has_solution(check.parts{check.part_counter});
 endfunction
 
 function check_error(message)
   global check;
-  check.parts(check.part_counter).valid = 0;
+  check.parts{check.part_counter}.valid = 0;
   check_feedback(message);
 endfunction
 
 function check_feedback(message)
   global check;
 	% append feedbact
-  check.parts(check.part_counter).feedback(end+1) = {message};
+  check.parts{check.part_counter}.feedback(end+1) = {message};
 endfunction
 
 function res = check_equal(koda, rezultat)
@@ -43,22 +43,22 @@ endfunction
 
 function check_secret(x,hint="")
   global check;
-  check.parts(check.part_counter).secret{end+1} = x;
+  check.parts{check.part_counter}.secret{end+1} = x;
 endfunction
 
 function check_summarize()
   global check;
   for i=1:check.part_counter
-    if not(check_has_solution(check.parts(i)))
+    if not(check_has_solution(check.parts{i}))
       printf('%d. podnaloga je brez rešitve.\n', i);
-    elseif not(check.parts(i).valid)
+    elseif not(check.parts{i}.valid)
       printf('%d. podnaloga nima veljavne rešitve.\n',i);
     else
       printf('%d. podnaloga ima veljavno rešitev.\n', i);
     end
-    for j = 1:length(check.parts(i).feedback)
+    for j = 1:length(check.parts{i}.feedback)
       printf('  - %d ',j);
-      disp(char(check.parts(i).feedback(j)));
+      disp(char(check.parts{i}.feedback(j)));
     end
   end
 endfunction

--- a/web/problems/templates/octave/edit.m
+++ b/web/problems/templates/octave/edit.m
@@ -1,0 +1,123 @@
+global check;
+check = struct();
+src = char(fileread(mfilename("fullpathext")));
+eval(strsplit(src,["# =L=I=B=R" "=A=R=Y=@="]){2});
+
+
+file_parts = extract_parts(src);
+check_initialize(file_parts);
+{% load i18n %}
+# NE BRIŠI prvih vrstic
+
+# =============================================================================
+# {{ problem.title|safe }}{% if problem.description %}
+#
+# {{ problem.description|indent:"# "|safe }}{% endif %}{% for part in problem.parts.all %}
+# =====================================================================@{{ part.id|stringformat:'06d'}}=
+# {{ part.description|indent:"# "|safe }}
+# =============================================================================
+{{ part.solution|safe }}
+
+check_part()
+{{ part.validation|safe }}
+
+{% endfor %}
+# # =====================================================================@000000=
+# # {% blocktrans %}  This is a template for a new problem part. To create a new part, uncomment
+# # the template and fill in your content.
+# #
+# # Define a function `multiply(x, y)` that returns the product of `x` and `y`.
+# # For example:
+# #
+# #     octave> multiply(3, 7)
+# #     ans = 21
+# #     octave> multiply(6, 7)
+# #     ans = 42{% endblocktrans %}
+# # =============================================================================
+#
+# function p = {% trans "multiply" %}(x, y)
+#     p =  x * y
+# endfunction
+#
+# check_part()
+#
+# check_equal('{% trans "multiply" %}(3, 7)', 21)
+# check_equal('{% trans "multiply" %}(6, 7)', 42)
+# check_equal('{% trans "multiply" %}(10, 10)', 100)
+# check_secret({% trans "multiply" %}(100, 100))
+# check_secret({% trans "multiply" %}(500, 123))
+
+
+# ===========================================================================@=
+# {% trans "Do not change this line or anything below it." %}
+# =============================================================================
+
+validate_current_file(src,check.parts);
+
+# =L=I=B=R=A=R=Y=@=
+
+'Če vam Octave sporoča, da je v tej vrstici sintaktična napaka,';
+'se napaka v resnici skriva v zadnjih vrsticah vaše kode.';
+
+'Kode od tu naprej NE SPREMINJAJTE!';
+
+# check.m
+{% include 'octave/check_functions.m' %}
+# check.m
+# varargin2struct.m
+{% include 'octave/jsonlab.m' %}
+
+{% include 'octave/utils.m' %}
+
+function validation = validate_current_file(src,parts)
+#    def backup(filename):
+#        backup_filename = None
+#        suffix = 1
+#        while not backup_filename or os.path.exists(backup_filename):
+%            backup_filename = '{0}.{1}'.format(filename, suffix)
+%            suffix += 1
+%        shutil.copy(filename, backup_filename)
+%        return backup_filename
+%
+%
+ # split solution to solution and validation
+  n = length(parts);
+  valid = [];
+  for i=1:n
+    chunks = strsplit(parts{i}.solution,'check_part()');
+    parts{i}.problem = {{ problem.id }};
+    parts{i}.solution = chunks{1};
+    parts{i}.validation = chunks{2};
+    if parts{i}.part
+      parts{i}.id = parts{i}.part;
+    end
+    valid  = [valid parts{i}.valid];
+    parts{i} = rmfield(rmfield(rmfield(parts{i},'valid'),'feedback'),'part');
+  end
+  problem_regex = ['# =+\n',...                      # beginning of header
+      '# (?<title>[^\n]*)\n',...              # title
+      '(?<description>(#( [^\n]*)?\n)*)',...  # description
+      '(?=(# )?# =+@)',];                     # beginning of first part
+  [s, e, te, m, t, nm, sp] = regexp(src,problem_regex,'dotall');
+  problem = struct(
+    "parts",{parts},
+    "title",strtrim(nm.title),
+    "description",regexprep(strtrim(nm.description),'^#','','lineanchors'),
+    "id", {{ problem.id }},
+    "problem_set", {{ problem.problem_set.id }}
+  );
+  if all(valid)
+    shranim = input("Ali rešitve shranim na strežnik? (da/ne) ","s");
+    if strtrim(shranim) == "da"
+      printf('Shranjujem rešitve na strežnik... ');
+      url = "{{ submission_url }}"; #'https://www.projekt-tomo.si/api/attempts/submit/';
+      token = "Token {{ authentication_token }}"; #'Token 0779d82c83d98c1e4a5480e4e6f57b906598f5ee';
+      response = submit_parts(problem, url, token);
+    end
+  else
+    disp("Problem ni dobro formuliran!");
+  end
+  check_summarize()
+endfunction
+
+# attempt.m

--- a/web/problems/templates/octave/jsonlab.m
+++ b/web/problems/templates/octave/jsonlab.m
@@ -1,0 +1,633 @@
+function opt=varargin2struct(varargin)
+%
+% opt=varargin2struct('param1',value1,'param2',value2,...)
+%   or
+% opt=varargin2struct(...,optstruct,...)
+%
+% convert a series of input parameters into a structure
+%
+% authors:Qianqian Fang (fangq<at> nmr.mgh.harvard.edu)
+% date: 2012/12/22
+%
+% input:
+%      'param', value: the input parameters should be pairs of a string and a value
+%       optstruct: if a parameter is a struct, the fields will be merged to the output struct
+%
+% output:
+%      opt: a struct where opt.param1=value1, opt.param2=value2 ...
+%
+% license:
+%     BSD or GPL version 3, see LICENSE_{BSD,GPLv3}.txt files for details
+%
+% -- this function is part of jsonlab toolbox (http://iso2mesh.sf.net/cgi-bin/index.cgi?jsonlab)
+%
+
+len=length(varargin);
+opt=struct;
+if(len==0) return; end
+i=1;
+while(i<=len)
+    if(isstruct(varargin{i}))
+        opt=mergestruct(opt,varargin{i});
+    elseif(ischar(varargin{i}) && i<len)
+        opt=setfield(opt,lower(varargin{i}),varargin{i+1});
+        i=i+1;
+    else
+        error('input must be in the form of ...,''name'',value,... pairs or structs');
+    end
+    i=i+1;
+end
+endfunction
+#jsonopt.m
+function val=jsonopt(key,default,varargin)
+%
+% val=jsonopt(key,default,optstruct)
+%
+% setting options based on a struct. The struct can be produced
+% by varargin2struct from a list of 'param','value' pairs
+%
+% authors:Qianqian Fang (fangq<at> nmr.mgh.harvard.edu)
+%
+% $Id: loadjson.m 371 2012-06-20 12:43:06Z fangq $
+%
+% input:
+%      key: a string with which one look up a value from a struct
+%      default: if the key does not exist, return default
+%      optstruct: a struct where each sub-field is a key
+%
+% output:
+%      val: if key exists, val=optstruct.key; otherwise val=default
+%
+% license:
+%     BSD or GPL version 3, see LICENSE_{BSD,GPLv3}.txt files for details
+%
+% -- this function is part of jsonlab toolbox (http://iso2mesh.sf.net/cgi-bin/index.cgi?jsonlab)
+%
+
+val=default;
+if(nargin<=2) return; end
+opt=varargin{1};
+if(isstruct(opt))
+    if(isfield(opt,key))
+       val=getfield(opt,key);
+    elseif(isfield(opt,lower(key)))
+       val=getfield(opt,lower(key));
+    end
+end
+endfunction
+# savejson.m
+function json=savejson(rootname,obj,varargin)
+%
+% json=savejson(rootname,obj,filename)
+%    or
+% json=savejson(rootname,obj,opt)
+% json=savejson(rootname,obj,'param1',value1,'param2',value2,...)
+%
+% convert a MATLAB object (cell, struct or array) into a JSON (JavaScript
+% Object Notation) string
+%
+% author: Qianqian Fang (fangq<at> nmr.mgh.harvard.edu)
+% created on 2011/09/09
+%
+% $Id$
+%
+% input:
+%      rootname: the name of the root-object, when set to '', the root name
+%        is ignored, however, when opt.ForceRootName is set to 1 (see below),
+%        the MATLAB variable name will be used as the root name.
+%      obj: a MATLAB object (array, cell, cell array, struct, struct array,
+%      class instance).
+%      filename: a string for the file name to save the output JSON data.
+%      opt: a struct for additional options, ignore to use default values.
+%        opt can have the following fields (first in [.|.] is the default)
+%
+%        opt.FileName [''|string]: a file name to save the output JSON data
+%        opt.FloatFormat ['%.10g'|string]: format to show each numeric element
+%                         of a 1D/2D array;
+%        opt.ArrayIndent [1|0]: if 1, output explicit data array with
+%                         precedent indentation; if 0, no indentation
+%        opt.ArrayToStruct[0|1]: when set to 0, savejson outputs 1D/2D
+%                         array in JSON array format; if sets to 1, an
+%                         array will be shown as a struct with fields
+%                         "_ArrayType_", "_ArraySize_" and "_ArrayData_"; for
+%                         sparse arrays, the non-zero elements will be
+%                         saved to _ArrayData_ field in triplet-format i.e.
+%                         (ix,iy,val) and "_ArrayIsSparse_" will be added
+%                         with a value of 1; for a complex array, the
+%                         _ArrayData_ array will include two columns
+%                         (4 for sparse) to record the real and imaginary
+%                         parts, and also "_ArrayIsComplex_":1 is added.
+%        opt.ParseLogical [0|1]: if this is set to 1, logical array elem
+%                         will use true/false rather than 1/0.
+%        opt.SingletArray [0|1]: if this is set to 1, arrays with a single
+%                         numerical element will be shown without a square
+%                         bracket, unless it is the root object; if 0, square
+%                         brackets are forced for any numerical arrays.
+%        opt.SingletCell  [1|0]: if 1, always enclose a cell with "[]"
+%                         even it has only one element; if 0, brackets
+%                         are ignored when a cell has only 1 element.
+%        opt.ForceRootName [0|1]: when set to 1 and rootname is empty, savejson
+%                         will use the name of the passed obj variable as the
+%                         root object name; if obj is an expression and
+%                         does not have a name, 'root' will be used; if this
+%                         is set to 0 and rootname is empty, the root level
+%                         will be merged down to the lower level.
+%        opt.Inf ['"$1_Inf_"'|string]: a customized regular expression pattern
+%                         to represent +/-Inf. The matched pattern is '([-+]*)Inf'
+%                         and $1 represents the sign. For those who want to use
+%                         1e999 to represent Inf, they can set opt.Inf to '$11e999'
+%        opt.NaN ['"_NaN_"'|string]: a customized regular expression pattern
+%                         to represent NaN
+%        opt.JSONP [''|string]: to generate a JSONP output (JSON with padding),
+%                         for example, if opt.JSONP='foo', the JSON data is
+%                         wrapped inside a function call as 'foo(...);'
+%        opt.UnpackHex [1|0]: conver the 0x[hex code] output by loadjson
+%                         back to the string form
+%        opt.SaveBinary [0|1]: 1 - save the JSON file in binary mode; 0 - text mode.
+%        opt.Compact [0|1]: 1- out compact JSON format (remove all newlines and tabs)
+%
+%        opt can be replaced by a list of ('param',value) pairs. The param
+%        string is equivallent to a field in opt and is case sensitive.
+% output:
+%      json: a string in the JSON format (see http://json.org)
+%
+% examples:
+%      jsonmesh=struct('MeshNode',[0 0 0;1 0 0;0 1 0;1 1 0;0 0 1;1 0 1;0 1 1;1 1 1],...
+%               'MeshTetra',[1 2 4 8;1 3 4 8;1 2 6 8;1 5 6 8;1 5 7 8;1 3 7 8],...
+%               'MeshTri',[1 2 4;1 2 6;1 3 4;1 3 7;1 5 6;1 5 7;...
+%                          2 8 4;2 8 6;3 8 4;3 8 7;5 8 6;5 8 7],...
+%               'MeshCreator','FangQ','MeshTitle','T6 Cube',...
+%               'SpecialData',[nan, inf, -inf]);
+%      savejson('jmesh',jsonmesh)
+%      savejson('',jsonmesh,'ArrayIndent',0,'FloatFormat','\t%.5g')
+%
+% license:
+%     BSD or GPL version 3, see LICENSE_{BSD,GPLv3}.txt files for details
+%
+% -- this function is part of JSONLab toolbox (http://iso2mesh.sf.net/cgi-bin/index.cgi?jsonlab)
+%
+
+if(nargin==1)
+   varname=inputname(1);
+   obj=rootname;
+   if(isempty(varname))
+      varname='root';
+   end
+   rootname=varname;
+else
+   varname=inputname(2);
+end
+if(length(varargin)==1 && ischar(varargin{1}))
+   opt=struct('filename',varargin{1});
+else
+   opt=varargin2struct(varargin{:});
+end
+opt.IsOctave=exist('OCTAVE_VERSION','builtin');
+if(isfield(opt,'norowbracket'))
+    warning('Option ''NoRowBracket'' is depreciated, please use ''SingletArray'' and set its value to not(NoRowBracket)');
+    if(~isfield(opt,'singletarray'))
+        opt.singletarray=not(opt.norowbracket);
+    end
+end
+rootisarray=0;
+rootlevel=1;
+forceroot=jsonopt('ForceRootName',0,opt);
+if((isnumeric(obj) || islogical(obj) || ischar(obj) || isstruct(obj) || ...
+        iscell(obj) || isobject(obj)) && isempty(rootname) && forceroot==0)
+    rootisarray=1;
+    rootlevel=0;
+else
+    if(isempty(rootname))
+        rootname=varname;
+    end
+end
+if((isstruct(obj) || iscell(obj))&& isempty(rootname) && forceroot)
+    rootname='root';
+end
+
+whitespaces=struct('tab',sprintf('\t'),'newline',sprintf('\n'),'sep',sprintf(',\n'));
+if(jsonopt('Compact',0,opt)==1)
+    whitespaces=struct('tab','','newline','','sep',',');
+end
+if(~isfield(opt,'whitespaces_'))
+    opt.whitespaces_=whitespaces;
+end
+
+nl=whitespaces.newline;
+
+json=obj2json(rootname,obj,rootlevel,opt);
+if(rootisarray)
+    json=sprintf('%s%s',json,nl);
+else
+    json=sprintf('{%s%s%s}\n',nl,json,nl);
+end
+
+jsonp=jsonopt('JSONP','',opt);
+if(~isempty(jsonp))
+    json=sprintf('%s(%s);%s',jsonp,json,nl);
+end
+
+% save to a file if FileName is set, suggested by Patrick Rapin
+filename=jsonopt('FileName','',opt);
+if(~isempty(filename))
+    if(jsonopt('SaveBinary',0,opt)==1)
+	    fid = fopen(filename, 'wb');
+	    fwrite(fid,json);
+    else
+	    fid = fopen(filename, 'wt');
+	    fwrite(fid,json,'char');
+    end
+    fclose(fid);
+end
+endfunction
+%%-------------------------------------------------------------------------
+function txt=obj2json(name,item,level,varargin)
+
+if(iscell(item))
+    txt=cell2json(name,item,level,varargin{:});
+elseif(isstruct(item))
+    txt=struct2json(name,item,level,varargin{:});
+elseif(ischar(item))
+    txt=str2json(name,item,level,varargin{:});
+elseif(isobject(item))
+    txt=matlabobject2json(name,item,level,varargin{:});
+else
+    txt=mat2json(name,item,level,varargin{:});
+end
+endfunction
+%%-------------------------------------------------------------------------
+function txt=cell2json(name,item,level,varargin)
+txt={};
+if(~iscell(item))
+        error('input is not a cell');
+end
+
+dim=size(item);
+if(ndims(squeeze(item))>2) % for 3D or higher dimensions, flatten to 2D for now
+    item=reshape(item,dim(1),numel(item)/dim(1));
+    dim=size(item);
+end
+len=numel(item);
+ws=jsonopt('whitespaces_',struct('tab',sprintf('\t'),'newline',sprintf('\n'),'sep',sprintf(',\n')),varargin{:});
+padding0=repmat(ws.tab,1,level);
+padding2=repmat(ws.tab,1,level+1);
+nl=ws.newline;
+bracketlevel=~jsonopt('singletcell',1,varargin{:});
+if(len>bracketlevel)
+    if(~isempty(name))
+        txt={padding0, '"', checkname(name,varargin{:}),'": [', nl}; name='';
+    else
+        txt={padding0, '[', nl};
+    end
+elseif(len==0)
+    if(~isempty(name))
+        txt={padding0, '"' checkname(name,varargin{:}) '": []'}; name='';
+    else
+        txt={padding0, '[]'};
+    end
+end
+for i=1:dim(1)
+    if(dim(1)>1)
+        txt(end+1:end+3)={padding2,'[',nl};
+    end
+    for j=1:dim(2)
+       txt{end+1}=obj2json(name,item{i,j},level+(dim(1)>1)+(len>bracketlevel),varargin{:});
+       if(j<dim(2))
+           txt(end+1:end+2)={',' nl};
+       end
+    end
+    if(dim(1)>1)
+        txt(end+1:end+3)={nl,padding2,']'};
+    end
+    if(i<dim(1))
+        txt(end+1:end+2)={',' nl};
+    end
+    %if(j==dim(2)) txt=sprintf('%s%s',txt,sprintf(',%s',nl)); end
+end
+if(len>bracketlevel)
+    txt(end+1:end+3)={nl,padding0,']'};
+end
+txt = sprintf('%s',txt{:});
+endfunction
+%%-------------------------------------------------------------------------
+function txt=struct2json(name,item,level,varargin)
+txt={};
+if(~isstruct(item))
+	error('input is not a struct');
+end
+dim=size(item);
+if(ndims(squeeze(item))>2) % for 3D or higher dimensions, flatten to 2D for now
+    item=reshape(item,dim(1),numel(item)/dim(1));
+    dim=size(item);
+end
+len=numel(item);
+forcearray= (len>1 || (jsonopt('SingletArray',0,varargin{:})==1 && level>0));
+ws=struct('tab',sprintf('\t'),'newline',sprintf('\n'));
+ws=jsonopt('whitespaces_',ws,varargin{:});
+padding0=repmat(ws.tab,1,level);
+padding2=repmat(ws.tab,1,level+1);
+padding1=repmat(ws.tab,1,level+(dim(1)>1)+forcearray);
+nl=ws.newline;
+
+if(isempty(item))
+    if(~isempty(name))
+        txt={padding0, '"', checkname(name,varargin{:}),'": []'};
+    else
+        txt={padding0, '[]'};
+    end
+    txt = sprintf('%s',txt{:});
+    return;
+end
+if(~isempty(name))
+    if(forcearray)
+        txt={padding0, '"', checkname(name,varargin{:}),'": [', nl};
+    end
+else
+    if(forcearray)
+        txt={padding0, '[', nl};
+    end
+end
+for j=1:dim(2)
+  if(dim(1)>1)
+      txt(end+1:end+3)={padding2,'[',nl};
+  end
+  for i=1:dim(1)
+    names = fieldnames(item(i,j));
+    if(~isempty(name) && len==1 && ~forcearray)
+        txt(end+1:end+5)={padding1, '"', checkname(name,varargin{:}),'": {', nl};
+    else
+        txt(end+1:end+3)={padding1, '{', nl};
+    end
+    if(~isempty(names))
+      for e=1:length(names)
+	    txt{end+1}=obj2json(names{e},item(i,j).(names{e}),...
+             level+(dim(1)>1)+1+forcearray,varargin{:});
+        if(e<length(names))
+            txt{end+1}=',';
+        end
+        txt{end+1}=nl;
+      end
+    end
+    txt(end+1:end+2)={padding1,'}'};
+    if(i<dim(1))
+        txt(end+1:end+2)={',' nl};
+    end
+  end
+  if(dim(1)>1)
+      txt(end+1:end+3)={nl,padding2,']'};
+  end
+  if(j<dim(2))
+      txt(end+1:end+2)={',' nl};
+  end
+end
+if(forcearray)
+    txt(end+1:end+3)={nl,padding0,']'};
+end
+txt = sprintf('%s',txt{:});
+endfunction
+%%-------------------------------------------------------------------------
+function txt=str2json(name,item,level,varargin)
+txt={};
+if(~ischar(item))
+        error('input is not a string');
+end
+item=reshape(item, max(size(item),[1 0]));
+len=size(item,1);
+ws=struct('tab',sprintf('\t'),'newline',sprintf('\n'),'sep',sprintf(',\n'));
+ws=jsonopt('whitespaces_',ws,varargin{:});
+padding1=repmat(ws.tab,1,level);
+padding0=repmat(ws.tab,1,level+1);
+nl=ws.newline;
+sep=ws.sep;
+
+if(~isempty(name))
+    if(len>1)
+        txt={padding1, '"', checkname(name,varargin{:}),'": [', nl};
+    end
+else
+    if(len>1)
+        txt={padding1, '[', nl};
+    end
+end
+for e=1:len
+    val=escapejsonstring(item(e,:));
+    if(len==1)
+        obj=['"' checkname(name,varargin{:}) '": ' '"',val,'"'];
+        if(isempty(name))
+            obj=['"',val,'"'];
+        end
+        txt(end+1:end+2)={padding1, obj};
+    else
+        txt(end+1:end+4)={padding0,'"',val,'"'};
+    end
+    if(e==len)
+        sep='';
+    end
+    txt{end+1}=sep;
+end
+if(len>1)
+    txt(end+1:end+3)={nl,padding1,']'};
+end
+txt = sprintf('%s',txt{:});
+endfunction
+%%-------------------------------------------------------------------------
+function txt=mat2json(name,item,level,varargin)
+if(~isnumeric(item) && ~islogical(item))
+        error('input is not an array');
+end
+ws=struct('tab',sprintf('\t'),'newline',sprintf('\n'),'sep',sprintf(',\n'));
+ws=jsonopt('whitespaces_',ws,varargin{:});
+padding1=repmat(ws.tab,1,level);
+padding0=repmat(ws.tab,1,level+1);
+nl=ws.newline;
+sep=ws.sep;
+
+if(length(size(item))>2 || issparse(item) || ~isreal(item) || ...
+   (isempty(item) && any(size(item))) ||jsonopt('ArrayToStruct',0,varargin{:}))
+    if(isempty(name))
+    	txt=sprintf('%s{%s%s"_ArrayType_": "%s",%s%s"_ArraySize_": %s,%s',...
+              padding1,nl,padding0,class(item),nl,padding0,regexprep(mat2str(size(item)),'\s+',','),nl);
+    else
+    	txt=sprintf('%s"%s": {%s%s"_ArrayType_": "%s",%s%s"_ArraySize_": %s,%s',...
+              padding1,checkname(name,varargin{:}),nl,padding0,class(item),nl,padding0,regexprep(mat2str(size(item)),'\s+',','),nl);
+    end
+else
+    if(numel(item)==1 && jsonopt('SingletArray',0,varargin{:})==0 && level>0)
+        numtxt=regexprep(regexprep(matdata2json(item,level+1,varargin{:}),'^\[',''),']','');
+    else
+        numtxt=matdata2json(item,level+1,varargin{:});
+    end
+    if(isempty(name))
+    	txt=sprintf('%s%s',padding1,numtxt);
+    else
+        if(numel(item)==1 && jsonopt('SingletArray',0,varargin{:})==0)
+           	txt=sprintf('%s"%s": %s',padding1,checkname(name,varargin{:}),numtxt);
+        else
+    	    txt=sprintf('%s"%s": %s',padding1,checkname(name,varargin{:}),numtxt);
+        end
+    end
+    return;
+end
+dataformat='%s%s%s%s%s';
+
+if(issparse(item))
+    [ix,iy]=find(item);
+    data=full(item(find(item)));
+    if(~isreal(item))
+       data=[real(data(:)),imag(data(:))];
+       if(size(item,1)==1)
+           % Kludge to have data's 'transposedness' match item's.
+           % (Necessary for complex row vector handling below.)
+           data=data';
+       end
+       txt=sprintf(dataformat,txt,padding0,'"_ArrayIsComplex_": ','1', sep);
+    end
+    txt=sprintf(dataformat,txt,padding0,'"_ArrayIsSparse_": ','1', sep);
+    if(size(item,1)==1)
+        % Row vector, store only column indices.
+        txt=sprintf(dataformat,txt,padding0,'"_ArrayData_": ',...
+           matdata2json([iy(:),data'],level+2,varargin{:}), nl);
+    elseif(size(item,2)==1)
+        % Column vector, store only row indices.
+        txt=sprintf(dataformat,txt,padding0,'"_ArrayData_": ',...
+           matdata2json([ix,data],level+2,varargin{:}), nl);
+    else
+        % General case, store row and column indices.
+        txt=sprintf(dataformat,txt,padding0,'"_ArrayData_": ',...
+           matdata2json([ix,iy,data],level+2,varargin{:}), nl);
+    end
+else
+    if(isreal(item))
+        txt=sprintf(dataformat,txt,padding0,'"_ArrayData_": ',...
+            matdata2json(item(:)',level+2,varargin{:}), nl);
+    else
+        txt=sprintf(dataformat,txt,padding0,'"_ArrayIsComplex_": ','1', sep);
+        txt=sprintf(dataformat,txt,padding0,'"_ArrayData_": ',...
+            matdata2json([real(item(:)) imag(item(:))],level+2,varargin{:}), nl);
+    end
+end
+txt=sprintf('%s%s%s',txt,padding1,'}');
+endfunction
+%%-------------------------------------------------------------------------
+function txt=matlabobject2json(name,item,level,varargin)
+if numel(item) == 0 %empty object
+    st = struct();
+else
+    % "st = struct(item);" would produce an inmutable warning, because it
+    % make the protected and private properties visible. Instead we get the
+    % visible properties
+    propertynames = properties(item);
+    for p = 1:numel(propertynames)
+        for o = numel(item):-1:1 % aray of objects
+            st(o).(propertynames{p}) = item(o).(propertynames{p});
+        end
+    end
+end
+txt=struct2json(name,st,level,varargin{:});
+endfunction
+%%-------------------------------------------------------------------------
+function txt=matdata2json(mat,level,varargin)
+
+ws=struct('tab',sprintf('\t'),'newline',sprintf('\n'),'sep',sprintf(',\n'));
+ws=jsonopt('whitespaces_',ws,varargin{:});
+tab=ws.tab;
+nl=ws.newline;
+
+if(size(mat,1)==1)
+    pre='';
+    post='';
+    level=level-1;
+else
+    pre=sprintf('[%s',nl);
+    post=sprintf('%s%s]',nl,repmat(tab,1,level-1));
+end
+
+if(isempty(mat))
+    txt='null';
+    return;
+end
+floatformat=jsonopt('FloatFormat','%.10g',varargin{:});
+%if(numel(mat)>1)
+    formatstr=['[' repmat([floatformat ','],1,size(mat,2)-1) [floatformat sprintf('],%s',nl)]];
+%else
+%    formatstr=[repmat([floatformat ','],1,size(mat,2)-1) [floatformat sprintf(',\n')]];
+%end
+
+if(nargin>=2 && size(mat,1)>1 && jsonopt('ArrayIndent',1,varargin{:})==1)
+    formatstr=[repmat(tab,1,level) formatstr];
+end
+
+txt=sprintf(formatstr,mat');
+txt(end-length(nl):end)=[];
+if(islogical(mat) && jsonopt('ParseLogical',0,varargin{:})==1)
+   txt=regexprep(txt,'1','true');
+   txt=regexprep(txt,'0','false');
+end
+%txt=regexprep(mat2str(mat),'\s+',',');
+%txt=regexprep(txt,';',sprintf('],\n['));
+% if(nargin>=2 && size(mat,1)>1)
+%     txt=regexprep(txt,'\[',[repmat(sprintf('\t'),1,level) '[']);
+% end
+txt=[pre txt post];
+if(any(isinf(mat(:))))
+    txt=regexprep(txt,'([-+]*)Inf',jsonopt('Inf','"$1_Inf_"',varargin{:}));
+end
+if(any(isnan(mat(:))))
+    txt=regexprep(txt,'NaN',jsonopt('NaN','"_NaN_"',varargin{:}));
+end
+endfunction
+%%-------------------------------------------------------------------------
+function newname=checkname(name,varargin)
+isunpack=jsonopt('UnpackHex',1,varargin{:});
+newname=name;
+if(isempty(regexp(name,'0x([0-9a-fA-F]+)_','once')))
+    return
+end
+if(isunpack)
+    isoct=jsonopt('IsOctave',0,varargin{:});
+    if(~isoct)
+        newname=regexprep(name,'(^x|_){1}0x([0-9a-fA-F]+)_','${native2unicode(hex2dec($2))}');
+    else
+        pos=regexp(name,'(^x|_){1}0x([0-9a-fA-F]+)_','start');
+        pend=regexp(name,'(^x|_){1}0x([0-9a-fA-F]+)_','end');
+        if(isempty(pos))
+            return;
+        end
+        str0=name;
+        pos0=[0 pend(:)' length(name)];
+        newname='';
+        for i=1:length(pos)
+            newname=[newname str0(pos0(i)+1:pos(i)-1) char(hex2dec(str0(pos(i)+3:pend(i)-1)))];
+        end
+        if(pos(end)~=length(name))
+            newname=[newname str0(pos0(end-1)+1:pos0(end))];
+        end
+    end
+end
+endfunction
+%%-------------------------------------------------------------------------
+function newstr=escapejsonstring(str)
+newstr=str;
+isoct=exist('OCTAVE_VERSION','builtin');
+if(isoct)
+   vv=sscanf(OCTAVE_VERSION,'%f');
+   if(vv(1)>=3.8)
+       isoct=0;
+   end
+end
+if(isoct)
+  escapechars={'\\','\"','\/','\a','\f','\n','\r','\t','\v'};
+  for i=1:length(escapechars);
+    newstr=regexprep(newstr,escapechars{i},escapechars{i});
+  end
+  newstr=regexprep(newstr,'\\\\(u[0-9a-fA-F]{4}[^0-9a-fA-F]*)','\$1');
+else
+  escapechars={'\\','\"','\/','\a','\b','\f','\n','\r','\t','\v'};
+  for i=1:length(escapechars);
+    newstr=regexprep(newstr,escapechars{i},regexprep(escapechars{i},'\\','\\\\'));
+  end
+  newstr=regexprep(newstr,'\\\\(u[0-9a-fA-F]{4}[^0-9a-fA-F]*)','\\$1');
+end
+endfunction
+
+# savejson.m

--- a/web/problems/templates/octave/utils.m
+++ b/web/problems/templates/octave/utils.m
@@ -1,0 +1,71 @@
+function parts = extract_parts(src)
+    part_regex = '# =+@(?<part>\d+)=\n';  # beginning of header
+    part_regex = [part_regex '(?<description>(#( [^\n]*)?\n)+)']; # description
+    part_regex = [part_regex '# =+\n'];           # end of header
+    part_regex = [part_regex '(?<solution>.*?)'];# solution
+    part_regex = [part_regex '(?=\n(# )?# =+@)'];     # beginning of next part
+
+    [s, e, te, m, t, nm, sp] = regexp(src,part_regex,'dotall');
+    parts = cell();
+    if iscell(nm.part)
+      for i=1:length(nm.part)
+        parts{end+1} =  struct("part",nm.part(i),
+          "solution", strtrim(nm.solution(i)),
+          "description", regexprep(strtrim(nm.description(i)),"^#","",'lineanchors')
+          );
+      end
+    else
+      parts{1} = struct("part",nm.part,
+      "solution",strtrim(nm.solution),
+      "description", regexprep(strtrim(nm.description),"^# ","",'lineanchors')
+      );
+    end
+    # The last solution extends all the way to the validation code,
+    # so we strip any trailing whitespace from it.
+endfunction
+
+function [response,output] = submit_parts(submited_parts, url, token)
+       #data = [data "]" ];
+       data = savejson('',submited_parts); #.encode('utf-8')
+       % test for python 3
+       py_version = 'import sys; print(sys.version_info[0])';
+       [r,out2] = system(["python -c '" py_version "'"]);
+       [r,out3] = system(["python3 -c '" py_version "'"]);
+       if str2num(out2) == 3
+         py_cmd = 'python';
+       elseif str2num(out3) == 3
+         py_cmd = 'python3';
+       else
+         disp("napaka: Python ni na voljo!\nProsimo, da namestite Python 3 (www.python.org) in poskrbite, da je v sistemski poti.")
+       end
+       printf("Shranjujem na strežnik ... ")
+       py_code = [...
+       "import json, urllib.request\n",...
+       'data = r"""', data, "\n",'"""',"\n",...
+       'blk_data = data.encode("utf-8")',"\n"...
+       'headers = { "Authorization": "' token '","content-type": "application/json" }',"\n"...
+       'request = urllib.request.Request("' url '", data=blk_data, headers=headers)',"\n"...
+       "response = urllib.request.urlopen(request)\n"...
+       'print(response.read().decode("utf-8"))'];
+       # 'response = json.loads(response.read().decode("utf-8"))',"\n",...
+       # 'for part in response["attempts"]:',"\n",...
+       # '  print("%s: %d" %(part["part"],part["valid"]))'];
+       # TODO print feedback as well
+       # disp(pycall)
+       py_file = tempname();
+       fp = fopen(py_file,'wt'); fwrite(fp,py_code); fclose(fp);
+       #'response = post(''' url ''')'
+       #'print(response.text)"']
+       %[response,output] = system([py_cmd " -c '" py_code "' 2>&1"]);
+       [response,output] = system([py_cmd " " py_file " 2>&1"]);
+       unlink(py_file); # clean tmp file
+       if response
+         disp('PRI SHRANJEVANJU JE PRIŠLO DO NAPAKE! Poskusite znova.')
+         disp(output)
+       else
+         disp('OK')
+       end
+       #request = urllib.request.Request(url, data=data, headers=headers)
+       #response = urllib.request.urlopen(request)
+       #return json.loads(response.read().decode('utf-8'))
+endfunction

--- a/web/web/settings/common.py
+++ b/web/web/settings/common.py
@@ -54,4 +54,3 @@ TEMPLATE_DIRS = (
 LOCALE_PATHS = (
     os.path.join(BASE_DIR, 'locale'),
 )
-


### PR DESCRIPTION
Dodal sem polje za programski jezik, ki ga lahko nastaviš za posamezno nalogo. Dodal sem tudi rudimentalno podporo za octave. Žal  urlread funkcija, ki pride z octave ne omogoča nastavljanja headerjev, zato sem iz octave klical python3. Uporabnik mora namestiti python3, če želi, da se naloge in poskusi naložijo na strežnik. 