### PR TITLE
Boljša imena datotek

### DIFF
--- a/web/courses/models.py
+++ b/web/courses/models.py
@@ -303,7 +303,7 @@ class ProblemSet(OrderWithRespectToMixin, models.Model):
                     user_attempts.append(attempt_dict[user.id].get(part.id))
             users.append((user, user_attempts))
 
-        spreadsheet_filename = "{0}.csv".format(self.title)
+        spreadsheet_filename = f"{slugify(self.title)}.csv"
         spreadsheet_contents = render_to_string(
             "results.csv", {"problem_set": self, "users": users}
         )

--- a/web/problems/models.py
+++ b/web/problems/models.py
@@ -63,7 +63,7 @@ class Problem(OrderWithRespectToMixin, models.Model):
 
     @property
     def slug(self):
-        return slugify(self.title).replace("-", "_")
+        return f'{self._order + 1:0>2}_{slugify(self.title).replace("-", "_")}'
 
     def attempt_file(self, user):
         authentication_token = Token.objects.get(user=user)
@@ -73,9 +73,8 @@ class Problem(OrderWithRespectToMixin, models.Model):
             for part in self.parts.all()
         ]
         url = settings.SUBMISSION_URL + reverse("attempts-submit")
-        problem_slug = slugify(self.title).replace("-", "_")
         extension = self.EXTENSIONS[self.language]
-        filename = f"{problem_slug}.{extension}"
+        filename = f"{self.slug}.{extension}"
         contents = render_to_string(
             f"{self.language}/attempt.{extension}",
             {
@@ -89,9 +88,8 @@ class Problem(OrderWithRespectToMixin, models.Model):
 
     def solution_file(self):
         parts = [(part, part.solution) for part in self.parts.all()]
-        problem_slug = slugify(self.title).replace("-", "_")
         extension = self.EXTENSIONS[self.language]
-        filename = f"{problem_slug}_solution.{extension}"
+        filename = f"{self.slug}_solution.{extension}"
         contents = render_to_string(
             f"{self.language}/solution.{extension}",
             {
@@ -147,8 +145,7 @@ class Problem(OrderWithRespectToMixin, models.Model):
         """
         authentication_token = Token.objects.get(user=user)
         url = settings.SUBMISSION_URL + reverse("problems-submit")
-        problem_slug = slugify(self.title).replace("-", "_")
-        filename = f"{problem_slug}_edit.{self.EXTENSIONS[self.language]}"
+        filename = f"{self.slug}_edit.{self.EXTENSIONS[self.language]}"
         contents = render_to_string(
             f"{self.language}/edit.{self.EXTENSIONS[self.language]}",
             {


### PR DESCRIPTION
# Zaporedne številke nalog v sklopu

Pred kakim letom smo govorili o tem, da bi bilo lepo, da je 7. problem v sklopu tudi 7. po abecedi (da ni treba iskati).

@schrjako je predlagal `problem._order`, kar sem vključil v `@property slug` (in ta property dejansko uporabil v kodi :)).

Spremenjena so imena

- attempt
- solution
- edit

datotek. Poleg testov gre malo ročnega klikanja lepo skozi.

# Hrošč v rezultatih

Popravil sem še to:
![slika](https://github.com/ul-fmf/projekt-tomo/assets/9413540/5566c9a8-dc57-4b07-93aa-b2289d9ebcbc)
